### PR TITLE
Feature: direct pipe

### DIFF
--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -12,6 +12,7 @@ namespace GitWrap
     class Program
     {
         private static Random random = new Random();
+
         static void Main(string[] args)
         {
             // Bash.exe
@@ -61,16 +62,20 @@ namespace GitWrap
 
         static void CaptureOutput(object sender, DataReceivedEventArgs e)
         {
-            if (e.Data != null && e.Data.Length > 1)
+            if (e.Data != null)
             {
-                String outputString = e.Data.Replace("\n", Environment.NewLine);
-                Console.WriteLine(outputString);
+                String outputString = e.Data + Environment.NewLine;
+                Console.Write(outputString);
             }
         }
 
         static void CaptureError(object sender, DataReceivedEventArgs e)
         {
-            Console.WriteLine(e.Data);
+            if (e.Data != null)
+            {
+                String outputString = e.Data + Environment.NewLine;
+                Console.Write(outputString);
+            }
         }
     }
 }

--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -61,7 +61,11 @@ namespace GitWrap
 
         static void CaptureOutput(object sender, DataReceivedEventArgs e)
         {
-            Console.WriteLine(e.Data);
+            if (e.Data != null && e.Data.Length > 1)
+            {
+                String outputString = e.Data.Replace("\n", Environment.NewLine);
+                Console.WriteLine(outputString);
+            }
         }
 
         static void CaptureError(object sender, DataReceivedEventArgs e)

--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -20,7 +20,7 @@ namespace GitWrap
             @"System32\bash.exe");
 
             // Loop through args and pass them to git executable
-            String argsString = "-c \" git";
+            String argsString = "-c \"git";
             for (int i = 0; i < args.Length; i++)
             {
                 // Translate directory structure.
@@ -37,38 +37,36 @@ namespace GitWrap
                 argstr = argstr.Replace("\\", "/");
                 argsString += " " + argstr;
             }
-            string oFilename = "gitwrap_output_" + RandomString(12);
-            argsString += "> /tmp/" + oFilename + " && chmod 777 /tmp/" + oFilename + "\"";
+
+            argsString += "\"";
             bashInfo.Arguments = argsString;
             bashInfo.UseShellExecute = false;
-            bashInfo.RedirectStandardOutput = false;
-            bashInfo.RedirectStandardError = false;
+            bashInfo.RedirectStandardOutput = true;
+            bashInfo.RedirectStandardError = true;
             bashInfo.CreateNoWindow = true;
 
             var proc = new Process
             {
                 StartInfo = bashInfo
             };
-            proc.Start();
-            proc.WaitForExit();
 
-            string outputFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                @"AppData\Local\lxss\rootfs\tmp\"+oFilename);
-            if (System.IO.File.Exists(outputFilePath))
-            {
-                //File.SetAttributes(outputFilePath, FileAttributes.Normal);
-                string text = System.IO.File.ReadAllText(outputFilePath);
-                text.Replace("\r\n", "\n");
-                System.Console.WriteLine(text);
-                System.IO.File.Delete(outputFilePath);
-            }
+            proc.OutputDataReceived += CaptureOutput;
+            proc.ErrorDataReceived += CaptureError;
+
+            proc.Start();
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+            proc.WaitForExit();
         }
 
-        public static string RandomString(int length)
+        static void CaptureOutput(object sender, DataReceivedEventArgs e)
         {
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-            return new string(Enumerable.Repeat(chars, length)
-              .Select(s => s[random.Next(s.Length)]).ToArray());
+            Console.WriteLine(e.Data);
+        }
+
+        static void CaptureError(object sender, DataReceivedEventArgs e)
+        {
+            Console.WriteLine(e.Data);
         }
     }
 }

--- a/GitWrap/GitWrap/Properties/AssemblyInfo.cs
+++ b/GitWrap/GitWrap/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("GitWrap")]
 [assembly: AssemblyDescription("Windows wrapper for Linux git")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Aegis Dynamics")]
+[assembly: AssemblyCompany("ardevd")]
 [assembly: AssemblyProduct("GitWrap")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
Now that WSL can properly pipe output from Linux applications to Windows we can write the output directly instead of the old workaround using temporary files.