### PR TITLE
Use a utility class for converting path styles

### DIFF
--- a/GitWrap/GitWrap/GitWrap.csproj
+++ b/GitWrap/GitWrap/GitWrap.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PathConverter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/GitWrap/GitWrap/PathConverter.cs
+++ b/GitWrap/GitWrap/PathConverter.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 
 namespace GitWrap

--- a/GitWrap/GitWrap/PathConverter.cs
+++ b/GitWrap/GitWrap/PathConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+
+namespace GitWrap
+{
+    public class PathConverter
+    {
+
+        public static string convertPathFromWindowsToLinux(String path)
+        {
+            // Translate directory structure.
+            // Use regex to translate drive letters.
+            string pattern = @"(\D):\\";
+            String argstr = path;
+            foreach (Match match in Regex.Matches(path, pattern, RegexOptions.IgnoreCase))
+            {
+                string driveLetter = match.Groups[1].ToString();
+                argstr = Regex.Replace(path, pattern, "/mnt/" + driveLetter.ToLower() + "/");
+            }
+
+            // Convert Windows path to Linux style paths
+            argstr = argstr.Replace("\\", "/");
+            // Escape any whitespaces
+            argstr = argstr.Replace(" ", "\\ ");
+            return argstr;
+        }
+    }
+}

--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace GitWrap
 {

--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -35,21 +35,7 @@ namespace GitWrap
 
             for (int i = 0; i < args.Length; i++)
             {
-                // Translate directory structure.
-                // Use regex to translate drive letters.
-                string pattern = @"(\D):\\";
-                String argstr = args[i];
-                foreach (Match match in Regex.Matches(args[i], pattern, RegexOptions.IgnoreCase))
-                {
-                    string driveLetter = match.Groups[1].ToString();
-                    argstr = Regex.Replace(args[i], pattern, "/mnt/" + driveLetter.ToLower() + "/");
-                }
-
-                // Convert Windows path to Linux style paths
-                argstr = argstr.Replace("\\", "/");
-                // Escape any whitespaces
-                argstr = argstr.Replace(" ", "\\ ");
-                argsBld.Append(" " + argstr);
+                argsBld.Append(" " + PathConverter.convertPathFromWindowsToLinux(args[i]));
             }
 
             // Append quotation to close of the argument supplied to bash.exe


### PR DESCRIPTION
Use the `PathConverter `utility class for all operations related to conversion of path styles. This makes it significantly easier to manage the code base.