### PR TITLE
Use wsl.exe instead of bash.exe for WSL command piping

### DIFF
--- a/GitWrap/GitWrap/Program.cs
+++ b/GitWrap/GitWrap/Program.cs
@@ -18,7 +18,7 @@ namespace GitWrap
         {
             if (!File.Exists(bashPath))
             {
-                Console.Write("[-] Error: Bash.exe not found.");
+                Console.Write("[-] Error: wsl.exe not found.");
                 return;
             }
 
@@ -27,15 +27,12 @@ namespace GitWrap
 
             // Loop through args and pass them to git executable
             StringBuilder argsBld = new StringBuilder();
-            argsBld.Append("-c \"git");
+            argsBld.Append("git");
 
             for (int i = 0; i < args.Length; i++)
             {
                 argsBld.Append(" " + PathConverter.convertPathFromWindowsToLinux(args[i]));
             }
-
-            // Append quotation to close of the argument supplied to bash.exe
-            argsBld.Append("\"");
 
             bashInfo.Arguments = argsBld.ToString();
             bashInfo.UseShellExecute = false;
@@ -70,7 +67,7 @@ namespace GitWrap
         static String getBashPath()
         {
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows),
-            @"System32\bash.exe");
+            @"System32\wsl.exe");
         }
 
         static void printOutputData(String data)


### PR DESCRIPTION
bash.exe is deprecated according to the [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/interop) and wsl.exe is what we're supposed to be using now.

An added benefit is the fact that we do not need to pass the -c option for running a single command
so we can drop the that and the associated quotations.