### PR TITLE
Use the native string type instead of the .NET String alias.

### DIFF
--- a/GitWrap/PathConverter.cs
+++ b/GitWrap/PathConverter.cs
@@ -11,7 +11,7 @@ namespace GitWrap
             // Translate directory structure.
             // Use regex to translate drive letters.
             string pattern = @"(\D):\\";
-            String argstr = path;
+            string argstr = path;
             foreach (Match match in Regex.Matches(path, pattern, RegexOptions.IgnoreCase))
             {
                 string driveLetter = match.Groups[1].ToString();


### PR DESCRIPTION
As far as guidelines, it's generally recommended to use string any time you're referring to an object.